### PR TITLE
Implement Excel IO utilities with caching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -136,7 +136,7 @@ def main() -> int:
             mapping=mapping,
         )
 
-    excel_io.save_workbook(args.excel)
+    excel_io.save(args.excel)
     return 0
 
 

--- a/src/bpauto/excel_io.py
+++ b/src/bpauto/excel_io.py
@@ -22,8 +22,10 @@ _WORKBOOK_CACHE: Dict[str, "Workbook"] = {}
 
 try:  # Lazy import for typing only
     from openpyxl.workbook import Workbook
+    from openpyxl.worksheet.worksheet import Worksheet
 except ImportError:  # pragma: no cover - openpyxl always provides Workbook
     Workbook = object  # type: ignore
+    Worksheet = object  # type: ignore
 
 
 def _get_or_load_workbook(excel_path: str) -> "Workbook":
@@ -35,6 +37,46 @@ def _get_or_load_workbook(excel_path: str) -> "Workbook":
         workbook = load_workbook(excel_path)
         _WORKBOOK_CACHE[excel_path] = workbook
     return workbook
+
+
+def _normalise_column(column: Optional[str]) -> Optional[str]:
+    if column is None:
+        return None
+    column = column.strip().upper()
+    return column or None
+
+
+def _cell_to_string(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value_str = value.strip()
+    else:
+        value_str = str(value).strip()
+    return value_str or None
+
+
+def _read_cell(worksheet: "Worksheet", column: Optional[str], row_index: int) -> Optional[str]:
+    column = _normalise_column(column)
+    if not column:
+        return None
+    cell = worksheet[f"{column}{row_index}"]
+    return _cell_to_string(cell.value)
+
+
+def _find_last_row_with_name(
+    worksheet: "Worksheet", name_column: str, start_row: int
+) -> int:
+    name_column = _normalise_column(name_column)
+    if not name_column:
+        raise ValueError("Name column must be provided")
+
+    max_row = worksheet.max_row
+    for row_idx in range(max_row, start_row - 1, -1):
+        value = _read_cell(worksheet, name_column, row_idx)
+        if value is not None:
+            return row_idx
+    return start_row - 1
 
 
 def iter_rows(
@@ -50,25 +92,50 @@ def iter_rows(
 
     workbook = _get_or_load_workbook(excel_path)
     worksheet = workbook[sheet]
-    stop = end or worksheet.max_row
+    normalised_name_col = _normalise_column(name_col)
+    if not normalised_name_col:
+        raise ValueError("Name column must be provided")
 
-    def _cell_value(column: Optional[str], row_index: int) -> Optional[str]:
-        if not column:
-            return None
-        column = column.strip().upper()
-        if not column:
-            return None
-        cell = worksheet[f"{column}{row_index}"]
-        value = cell.value
-        return value if value is None or isinstance(value, str) else str(value)
+    if end is not None:
+        stop = end
+    else:
+        stop = _find_last_row_with_name(worksheet, normalised_name_col, start)
 
-    for row_idx in range(start, stop + 1):
-        yield RowData(
-            index=row_idx,
-            name=_cell_value(name_col, row_idx),
-            zip=_cell_value(zip_col, row_idx),
-            country=_cell_value(country_col, row_idx),
+    logger.info(
+        "Iterating rows from %s to %s on sheet '%s' in workbook '%s'",
+        start,
+        stop,
+        sheet,
+        excel_path,
+    )
+
+    def _generator() -> Generator[RowData, None, None]:
+        yielded = 0
+        if stop < start:
+            logger.info(
+                "No rows to iterate for sheet '%s' in workbook '%s'", sheet, excel_path
+            )
+            return
+
+        for row_idx in range(start, stop + 1):
+            name_value = _read_cell(worksheet, normalised_name_col, row_idx)
+            if name_value is None:
+                continue
+
+            row_data: RowData = {
+                "index": row_idx,
+                "name": name_value,
+                "zip": _read_cell(worksheet, zip_col, row_idx),
+                "country": _read_cell(worksheet, country_col, row_idx),
+            }
+            yielded += 1
+            yield row_data
+
+        logger.info(
+            "Iterated %s row(s) from sheet '%s' in workbook '%s'", yielded, sheet, excel_path
         )
+
+    return _generator()
 
 
 def write_result(
@@ -83,18 +150,28 @@ def write_result(
     workbook = _get_or_load_workbook(excel_path)
     worksheet = workbook[sheet]
 
+    logger.info(
+        "Writing result for row %s on sheet '%s' in workbook '%s'",
+        row_index,
+        sheet,
+        excel_path,
+    )
+
     for key, column in mapping.items():
-        column = column.strip().upper()
-        if not column:
+        column_letter = _normalise_column(column)
+        if not column_letter:
             continue
         value = record.get(key)
         if value is None:
-            continue
-        cell = worksheet[f"{column}{row_index}"]
-        cell.value = value
+            cell_value = ""
+        elif isinstance(value, str):
+            cell_value = value
+        else:
+            cell_value = str(value)
+        worksheet[f"{column_letter}{row_index}"] = cell_value
 
 
-def save_workbook(excel_path: str) -> None:
+def save(excel_path: str) -> None:
     """Persist any pending changes to disk."""
 
     workbook = _WORKBOOK_CACHE.get(excel_path)
@@ -103,3 +180,10 @@ def save_workbook(excel_path: str) -> None:
         return
     logger.debug("Saving workbook: %s", excel_path)
     workbook.save(excel_path)
+
+
+def reset() -> None:
+    """Clear the workbook cache. Intended for test usage."""
+
+    logger.debug("Resetting workbook cache")
+    _WORKBOOK_CACHE.clear()


### PR DESCRIPTION
## Summary
- implement cached workbook handling, row iteration, and result writing utilities for Excel integration
- add workbook save/reset helpers and align CLI save call with new helper

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'handelsregister')*

------
https://chatgpt.com/codex/tasks/task_e_68e3afa5b8e483239802d2f3de2790f6