### PR TITLE
Document column mapping usage and add example YAML

### DIFF
--- a/README_API_INTEGRATION.md
+++ b/README_API_INTEGRATION.md
@@ -12,9 +12,13 @@
 
 2. Provide your NorthData API key:
 
+   **Linux / macOS (Bash):**
+
    ```bash
    export NORTHDATA_API_KEY=your_real_key
    ```
+
+   **Windows (PowerShell):**
 
    ```powershell
    $Env:NORTHDATA_API_KEY = "your_real_key"
@@ -25,3 +29,13 @@
    ```bash
    python cli.py --excel "Liste.xlsx" --sheet "Tabelle1" --start 3 --end 20 --name-col C --zip-col I --country-col J --source api
    ```
+
+## Column Mapping
+
+You can provide a YAML file to control how Excel columns map to the NorthData `CompanyRecord` fields. An example mapping is included at `mappings/example_mapping.yaml`.
+
+Run the CLI with the `--mapping-yaml` flag to use the mapping file and automatically download additional documents:
+
+```bash
+python cli.py --excel "Liste.xlsx" --sheet "Tabelle1" --start 3 --end 10 --name-col C --zip-col I --country-col J --source api --mapping-yaml mappings/example_mapping.yaml --download-ad
+```

--- a/mappings/example_mapping.yaml
+++ b/mappings/example_mapping.yaml
@@ -1,0 +1,10 @@
+# Keys are CompanyRecord keys, values are Excel column letters
+legal_name: W
+register_type: U
+register_no: V
+street: X
+zip: Y
+city: Z
+pdf_path: AA
+notes: AB
+country: AC


### PR DESCRIPTION
## Summary
- add an example column mapping YAML file for NorthData integration
- document how to provide the mapping file when running the CLI, including environment setup instructions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3b36d8bec8323868b4a28b225548f