### PR TITLE
Add smoke test for NorthData provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: smoke
+
+smoke:
+	python -m tests.smoke_fetch

--- a/tests/smoke_fetch.py
+++ b/tests/smoke_fetch.py
@@ -1,0 +1,32 @@
+"""Simple smoke test for NorthData provider."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from bpauto.providers import NorthDataProvider
+
+
+def main() -> int:
+    dotenv_path = Path(".env")
+    if dotenv_path.exists():
+        load_dotenv(dotenv_path=dotenv_path)
+
+    provider = NorthDataProvider(download_ad=False)
+    record = provider.fetch(name="Siemens AG", zip_code="80333", country="DE")
+
+    print(json.dumps(record, indent=2, sort_keys=True, ensure_ascii=False))
+
+    notes = record.get("notes")
+    if isinstance(notes, str) and "no result" in notes.lower():
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a smoke test script that fetches Siemens AG data via the NorthData provider
- add a Makefile target to run the smoke test via `python -m tests.smoke_fetch`

## Testing
- not run (requires `NORTHDATA_API_KEY` credentials)


------
https://chatgpt.com/codex/tasks/task_e_68e3b63ed7608323862cdddf74fc28aa