### PR TITLE
Save workbook after each API result

### DIFF
--- a/src/bpauto/cli.py
+++ b/src/bpauto/cli.py
@@ -253,9 +253,7 @@ def main() -> int:
                 record=record,
                 mapping=mapping,
             )
-
-    if not args.dry_run:
-        excel_io.save(args.excel)
+            excel_io.save(args.excel)
 
     duration = time.perf_counter() - start_time
     LOGGER.info(


### PR DESCRIPTION
## Summary
- ensure the CLI persists the Excel workbook immediately after writing each API result

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68e7a3bb54188323a7ab58e537a07948