### PR TITLE
Improve Excel name combination logic

### DIFF
--- a/tests/test_excel_io.py
+++ b/tests/test_excel_io.py
@@ -37,6 +37,31 @@ def _create_workbook(path: Path) -> None:
     workbook.save(path)
 
 
+def test_iter_rows_combines_multiple_name_columns(tmp_path: Path) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Daten"
+    sheet["C2"] = "Another GmbH & Co."
+    sheet["D2"] = "KG"
+    sheet["C3"] = "Solo AG"
+    sheet["D3"] = "n.n."
+    path = tmp_path / "names.xlsx"
+    workbook.save(path)
+
+    rows = list(
+        excel_io.iter_rows(
+            excel_path=str(path),
+            sheet="Daten",
+            start=2,
+            end=3,
+            name_col="C",
+            name_additional_cols=("D",),
+        )
+    )
+
+    assert [row["name"] for row in rows] == ["Another GmbH & Co. KG", "Solo AG"]
+
+
 def test_iter_rows_trims_and_skips_blank(tmp_path: Path) -> None:
     excel_path = tmp_path / "test.xlsx"
     _create_workbook(excel_path)


### PR DESCRIPTION
## Summary
- add suffix and noise handling helpers so `_combine_name_parts` can validate combined names before falling back to single fragments
- allow `iter_rows` to accept additional name columns and use the new combining routine when building row data
- extend the Excel IO tests to cover multi-column company names such as "Another GmbH & Co." + "KG"

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7ab53daa083238fb21ddd51f0772f