### PR TITLE
Avoid writing Excel rows for unsuccessful API hits

### DIFF
--- a/src/bpauto/cli.py
+++ b/src/bpauto/cli.py
@@ -241,12 +241,13 @@ def main() -> int:
             continue
 
         notes = (record.get("notes") or "").lower()
-        if "no result" in notes:
-            no_result += 1
-        else:
+        is_hit = "no result" not in notes
+        if is_hit:
             hits += 1
+        else:
+            no_result += 1
 
-        if not args.dry_run:
+        if is_hit and not args.dry_run:
             excel_io.write_result(
                 excel_path=args.excel,
                 sheet=args.sheet,


### PR DESCRIPTION
## Summary
- ensure the CLI skips writing results when the API reports "no result"

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68e7b0126ff88323950bed991179fc61