### PR TITLE
Skip unsupported countries when processing rows

### DIFF
--- a/src/bpauto/cli.py
+++ b/src/bpauto/cli.py
@@ -32,6 +32,28 @@ DEFAULT_MAPPING: dict[str, str] = {
 
 API_HIT_DATE_COLUMN = "S"
 
+SUPPORTED_COUNTRY_CODES: set[str] = {
+    "AT",
+    "BE",
+    "CH",
+    "CY",
+    "CZ",
+    "DE",
+    "DK",
+    "ES",
+    "FI",
+    "FR",
+    "GB",
+    "IE",
+    "IL",
+    "LI",
+    "LU",
+    "NL",
+    "NO",
+    "PL",
+    "SE",
+}
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="BP Automation NorthData Integration")
@@ -211,6 +233,15 @@ def main() -> int:
         zip_clean = _normalise_address_component(zip_code)
         city_clean = _normalise_address_component(city)
         country_clean = _normalise_address_component(country)
+        country_code = country_clean.upper() if country_clean else None
+        if country_code is None or country_code not in SUPPORTED_COUNTRY_CODES:
+            LOGGER.debug(
+                "Überspringe Zeile %s mit nicht unterstütztem Land %s",
+                row.get("index"),
+                country_clean or "-",
+            )
+            continue
+        country_clean = country_code
 
         LOGGER.debug(
             "Zeile %s: Verwende address-Parameter für NorthData: %s",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from bpauto import cli
+
+
+def test_main_skips_rows_with_unsupported_country(monkeypatch):
+    rows = [
+        {
+            "index": 3,
+            "name": "Allowed GmbH",
+            "zip": "10115",
+            "city": "Berlin",
+            "country": "DE",
+            "street": None,
+            "house_number": None,
+        },
+        {
+            "index": 4,
+            "name": "Blocked GmbH",
+            "zip": "75008",
+            "city": "Paris",
+            "country": "US",
+            "street": None,
+            "house_number": None,
+        },
+    ]
+
+    def fake_iter_rows(**_: object):
+        for row in rows:
+            yield row
+
+    fetch_calls: list[dict[str, object]] = []
+
+    class DummyProvider:
+        def __init__(self, download_ad: bool):
+            self.download_ad = download_ad
+
+        def fetch(self, **kwargs: object) -> dict[str, object]:
+            fetch_calls.append(kwargs)
+            return {"notes": ""}
+
+    args = Namespace(
+        excel="dummy.xlsx",
+        sheet="Sheet1",
+        start=3,
+        end=None,
+        name_col="C",
+        zip_col=None,
+        city_col=None,
+        country_col="J",
+        street_col=None,
+        house_number_col=None,
+        mapping_yaml=None,
+        source="api",
+        download_ad=False,
+        verbose=False,
+        dry_run=True,
+    )
+
+    monkeypatch.setattr(cli, "_parse_args", lambda: args)
+    monkeypatch.setattr(cli.excel_io, "iter_rows", fake_iter_rows)
+    monkeypatch.setattr(cli, "NorthDataProvider", DummyProvider)
+
+    exit_code = cli.main()
+
+    assert exit_code == 0
+    assert len(fetch_calls) == 1
+    assert fetch_calls[0]["country"] == "DE"


### PR DESCRIPTION
## Summary
- add a whitelist of supported country codes to the CLI processing logic
- normalize country values and skip rows with countries outside the supported list
- cover the new behaviour with a CLI unit test that ensures only supported countries are processed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e96dde1b0c83239ef7a235d984d3de