### PR TITLE
Set default country column to J

### DIFF
--- a/src/bpauto/cli.py
+++ b/src/bpauto/cli.py
@@ -65,7 +65,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--name-col", default="C", help="Spalte mit Firmenname (Standard: C)")
     parser.add_argument("--zip-col", default=None, help="Spalte mit Postleitzahl (optional)")
     parser.add_argument("--city-col", default=None, help="Spalte mit Ort (optional)")
-    parser.add_argument("--country-col", default=None, help="Spalte mit Ländercode (optional)")
+    parser.add_argument(
+        "--country-col",
+        default="J",
+        help="Spalte mit Ländercode (Standard: J)",
+    )
     parser.add_argument("--street-col", default=None, help="Spalte mit Straße (optional)")
     parser.add_argument(
         "--house-number-col", default=None, help="Spalte mit Hausnummer (optional)"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from argparse import Namespace
 
 from bpauto import cli
@@ -68,3 +69,18 @@ def test_main_skips_rows_with_unsupported_country(monkeypatch):
     assert exit_code == 0
     assert len(fetch_calls) == 1
     assert fetch_calls[0]["country"] == "DE"
+
+
+def test_parse_args_sets_default_country_column(monkeypatch):
+    argv = [
+        "bpauto",
+        "--excel",
+        "dummy.xlsx",
+        "--sheet",
+        "Sheet1",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    args = cli._parse_args()
+
+    assert args.country_col == "J"


### PR DESCRIPTION
## Summary
- default the CLI `--country-col` option to column J to match the spreadsheet layout
- add a regression test that ensures the parser injects the new default value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e9788b73f4832399bb278c25fa21f2